### PR TITLE
Form translation and styling

### DIFF
--- a/app/javascript/stylesheets/components/_loginform.scss
+++ b/app/javascript/stylesheets/components/_loginform.scss
@@ -31,5 +31,5 @@
 }
 
 #error_explanation {
-  @apply text-xs;
+  @apply text-xs text-center;
 }

--- a/app/javascript/stylesheets/components/_loginform.scss
+++ b/app/javascript/stylesheets/components/_loginform.scss
@@ -1,27 +1,35 @@
 .log-in-form {
-    @apply text-center
+  @apply text-center;
 }
 
 .input-form-border-purple {
-    @apply border-2 border-secondary-100 px-2 py-4 rounded-2xl md:w-1/3 mb-4 lg:mb-8 text-center;
+  @apply border-2 border-secondary-100 px-2 py-4 rounded-2xl md:w-1/2 mb-2 lg:mb-2 text-center;
 }
 
 .input-form-border-purple-small {
-    @apply border-2 border-secondary-100 px-2 py-4 rounded-2xl w-1/5 text-center;
+  @apply border-2 border-secondary-100 px-2 py-4 rounded-2xl w-1/5 text-center;
 }
 
 .remember-me {
-    @apply flex justify-center items-center mb-4;
+  @apply flex justify-center items-center mb-4;
 }
 
 #user_remember_me {
-    @apply mr-3;
+  @apply mr-3;
 }
 
 .placeholder {
-    @apply font-default font-medium text-base opacity-50;
+  @apply font-default font-medium text-base opacity-50;
 }
 
 .logincard {
-    @apply bg-white px-8 py-16 max-w-xl mx-auto rounded-xl shadow-md;
+  @apply bg-white px-8 py-16 max-w-xl mx-auto rounded-xl shadow-md;
+}
+
+.field_with_errors {
+  @apply mb-1 text-xs;
+}
+
+#error_explanation {
+  @apply text-xs;
 }

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,13 +15,14 @@
         <div class="field">
           <%= f.input :email, autofocus: true, autocomplete: "email", label: false, input_html: { class: 'input-form-border-purple placeholder', placeholder: "E-mail" }%>
         </div>
-      
+  
         <div class="field">
         <%= f.input :username,
                       required: true,
                       label: false,
                       input_html: { autocomplete: "off", class: 'input-form-border-purple placeholder', placeholder: "Pseudo" }%>
         </div>
+    
         <div class="field">
           <%= f.input :password, autocomplete: "new-password", label: false, input_html: { class: 'input-form-border-purple placeholder', placeholder: "Mot de passe" } %>
         </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -20,7 +20,7 @@
         <%= f.input :username,
                       required: true,
                       label: false,
-                      input_html: { autocomplete: "username", class: 'input-form-border-purple placeholder', placeholder: "Pseudo" }%>
+                      input_html: { autocomplete: "off", class: 'input-form-border-purple placeholder', placeholder: "Pseudo" }%>
         </div>
         <div class="field">
           <%= f.input :password, autocomplete: "new-password", label: false, input_html: { class: 'input-form-border-purple placeholder', placeholder: "Mot de passe" } %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -6,10 +6,12 @@
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
+    
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>
     </ul>
   </div>
+ 
 <% end %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -55,7 +55,7 @@ SimpleForm.setup do |config|
     # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
     b.use :label_input
     b.use :hint,  wrap_with: { tag: :span, class: :hint }
-    b.use :error, wrap_with: { tag: :span, class: :error }
+    b.use :error, wrap_with: { tag: :div, class: :error }
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can


### PR DESCRIPTION
Changed CSS styling to avoid misalignment of input fields when there is an error in the sign up and password recovery form