### PR TITLE
Google error when no picture

### DIFF
--- a/app/controllers/ongoing_tasks_controller.rb
+++ b/app/controllers/ongoing_tasks_controller.rb
@@ -37,22 +37,15 @@ class OngoingTasksController < ApplicationController
 
       ValidateTasksJob.set(wait: 4.hours).perform_later(@ongoing_task) if @ongoing_task.task.recurrence == "daily" 
       add_task_points_to_colocs_points(@ongoing_task)
-
-
       redirect_to ongoing_tasks_path
     else
+      build_helpers
       render :validate_task
     end
   end
 
   def validate_task
-    potential_helpers = User.where(coloc_id: current_user.coloc.id).where.not(id: current_user.id)
-    helpers_ids_array = helpers_that_where_already_selected
-    potential_helpers.each do |potential_helper|
-      unless helpers_ids_array.include? potential_helper.id
-        @ongoing_task.helpers.build(user: potential_helper, ongoing_task_id: @ongoing_task.id)
-      end
-    end
+    build_helpers
   end
 
   def start_ongoing_tasks
@@ -75,6 +68,16 @@ class OngoingTasksController < ApplicationController
 
   def ongoing_task_params
     params.require(:ongoing_task).permit(:name, :photo_after, :photo_before, helpers_attributes: [ :ongoing_task_id, :user_id])
+  end
+
+  def build_helpers
+    potential_helpers = User.where(coloc_id: current_user.coloc.id).where.not(id: current_user.id)
+    helpers_ids_array = helpers_that_where_already_selected
+    potential_helpers.each do |potential_helper|
+      unless helpers_ids_array.include? potential_helper.id
+        @ongoing_task.helpers.build(user: potential_helper, ongoing_task_id: @ongoing_task.id)
+      end
+    end
   end
 
   def cannot_validate_done_task

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,35 +3,38 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
+import Rails from "@rails/ujs";
+import Turbolinks from "turbolinks";
+import * as ActiveStorage from "@rails/activestorage";
+import "channels";
 // import { displayTabs } from '../plugins/display_tabs.js';
-import { initPictureInput } from '../plugins/preview_picture.js';
-import { initClickableTasks, initCloseTaskClickOutside, initCloseTaskModal } from '../plugins/modals';
-import { coloredSwitchButtons } from '../plugins/toggle_switch_button.js'
-import { displayTextIconHovered } from '../plugins/hovered_icon_text.js'
+import { initPictureInput } from "../plugins/preview_picture.js";
+import {
+  initClickableTasks,
+  initCloseTaskClickOutside,
+  initCloseTaskModal,
+} from "../plugins/modals";
+import { coloredSwitchButtons } from "../plugins/toggle_switch_button.js";
+// import { displayTextIconHovered } from '../plugins/hovered_icon_text.js'
 
-Rails.start()
-Turbolinks.start()
-ActiveStorage.start()
+Rails.start();
+Turbolinks.start();
+ActiveStorage.start();
 
 import "stylesheets/application";
 
-document.addEventListener('turbolinks:load', () => {
-    // const allTabs = document.querySelectorAll('.tablinks')
-    // if (allTabs) {
-    //     allTabs.forEach((tab) => {
-    //         tab.addEventListener('click', ((event) => {
-    //             displayTabs(event, tab.dataset.tabname)
-    //         }))
-    //     })
-    // }
-    initClickableTasks();
-    initCloseTaskClickOutside();
-    initCloseTaskModal();
-    initPictureInput();
-    coloredSwitchButtons();
-    displayTextIconHovered();
+document.addEventListener("turbolinks:load", () => {
+  // const allTabs = document.querySelectorAll('.tablinks')
+  // if (allTabs) {
+  //     allTabs.forEach((tab) => {
+  //         tab.addEventListener('click', ((event) => {
+  //             displayTabs(event, tab.dataset.tabname)
+  //         }))
+  //     })
+  // }
+  initClickableTasks();
+  initCloseTaskClickOutside();
+  initCloseTaskModal();
+  initPictureInput();
+  coloredSwitchButtons();
 });

--- a/app/models/ongoing_task.rb
+++ b/app/models/ongoing_task.rb
@@ -7,6 +7,8 @@ class OngoingTask < ApplicationRecord
   has_one_attached :photo_before
   has_one_attached :photo_after
 
+  validate :photo_after
+
   has_one :coloc, through: :coloc_task
   has_one :task, through: :coloc_task
   delegate :name, :description, :image, :auto_assigned, to: :task
@@ -39,6 +41,10 @@ class OngoingTask < ApplicationRecord
   scope :done, -> { where(done: true) }
   scope :daily_not_finished_unassigned_tasks, -> { unassigned_tasks.not_finished }
 
+  def photo_after
+    errors.add(:base, 'Veuillez valider avec une photo.') unless photo_after.attached?
+  end
+  
   def assigned?
     self.user
   end

--- a/app/models/ongoing_task.rb
+++ b/app/models/ongoing_task.rb
@@ -7,7 +7,7 @@ class OngoingTask < ApplicationRecord
   has_one_attached :photo_before
   has_one_attached :photo_after
 
-  validate :photo_after
+  validate :photo_after?, on: :validation_update
 
   has_one :coloc, through: :coloc_task
   has_one :task, through: :coloc_task
@@ -41,7 +41,7 @@ class OngoingTask < ApplicationRecord
   scope :done, -> { where(done: true) }
   scope :daily_not_finished_unassigned_tasks, -> { unassigned_tasks.not_finished }
 
-  def photo_after
+  def photo_after?
     errors.add(:base, 'Veuillez valider avec une photo.') unless photo_after.attached?
   end
   

--- a/app/models/ongoing_task.rb
+++ b/app/models/ongoing_task.rb
@@ -7,7 +7,7 @@ class OngoingTask < ApplicationRecord
   has_one_attached :photo_before
   has_one_attached :photo_after
 
-  validate :photo_after?, on: :validation_update
+  validate :photo_after?, on: :update
 
   has_one :coloc, through: :coloc_task
   has_one :task, through: :coloc_task


### PR DESCRIPTION
photo_after validation on update only. (Because we want to be able to create ongoing_task  without photo_after)

We build helpers in validation update in order to make appear when there is a problem with user validation.

Since we need the same code in two public methods, creation of a private one.